### PR TITLE
allow leading underscores for variables and properties

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -40,6 +40,7 @@ const typescriptRules = {
     {
       selector: 'variable',
       format: ['camelCase', 'UPPER_CASE', 'PascalCase'],
+      leadingUnderscore: 'allow',
     },
     {
       selector: 'property',
@@ -57,6 +58,7 @@ const typescriptRules = {
       selector: 'variable',
       types: ['function'],
       format: ['camelCase', 'PascalCase'],
+      leadingUnderscore: 'allow',
     },
     {
       selector: 'parameter',


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, bug report links, etc)
previously doing something like `_myVar` was disallowed for variables and properties. since prefixing with an underscore for unused or to avoid renaming variables is a pretty common pattern, i've added that to the rules