### PR TITLE
feat: allow unused vars in for array destructuring

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -95,8 +95,9 @@ const typescriptRules = {
   '@typescript-eslint/no-unused-vars': [
     2,
     {
-      ignoreRestSiblings: true,
       argsIgnorePattern: '^_',
+      ignoreRestSiblings: true,
+      varsIgnorePattern: '^_',
     },
   ],
   '@typescript-eslint/no-useless-constructor': 2,


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [ ] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [x] patch

## Further Information (screenshots, bug report links, etc)
allows things like
`const [a, _b, c] = useWhatever()`
where previously, `_b` would generate an error