### PR TITLE
fix: install deps before publish, remove unnecessary flag [norelease]

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -21,6 +21,9 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
           git config user.name "$GITHUB_ACTOR"
 
+      - name: Install
+        run: npm ci
+
       - name: Version
         env:
           PR_TITLE: ${{ toJson(github.event.head_commit.message) }}

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "eslint-check": "eslint --print-config . | eslint-config-prettier-check",
     "format": "prettier \"*.js\" \"rules/*.js\" --write && sortpack",
     "preversion": "npm t",
-    "test": "run-s -s test:lint test:test",
+    "test": "run-s test:lint test:test",
     "test:lint": "eslint -c .eslintrc.json *.js rules",
     "test:test": "node test"
   },


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [ ] Chore
* [x] Bug Fix

## Change Level

* [ ] major
* [ ] minor
* [ ] patch

## Further Information (screenshots, bug report links, etc)
the ci failed to publish last time because we weren't installing deps first and there is a preversion check that runs the tests