### PR TITLE
chore: replace deprecated babel-eslint-plugin, bump jest plugin[patch]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,14 @@
         "@babel/highlight": "^7.0.0"
       }
     },
+    "@babel/eslint-plugin": {
+      "version": "7.12.1",
+      "resolved": "https://registry.npmjs.org/@babel/eslint-plugin/-/eslint-plugin-7.12.1.tgz",
+      "integrity": "sha512-rOjrD5yupTYCO4x0kEbQmi/NsaD+VGOD/9Cvso64WMVPY2y6o5Nvw2sqFWdeSEBdR1Dsa07YjplBs067x5YbXg==",
+      "requires": {
+        "eslint-rule-composer": "^0.3.0"
+      }
+    },
     "@babel/generator": {
       "version": "7.10.4",
       "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
@@ -1227,14 +1235,6 @@
         }
       }
     },
-    "eslint-plugin-babel": {
-      "version": "5.3.1",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-babel/-/eslint-plugin-babel-5.3.1.tgz",
-      "integrity": "sha512-VsQEr6NH3dj664+EyxJwO4FCYm/00JhYb3Sk3ft8o+fpKuIfQ9TaW6uVUfvwMXHcf/lsnRIoyFPsLMyiWCSL/g==",
-      "requires": {
-        "eslint-rule-composer": "^0.3.0"
-      }
-    },
     "eslint-plugin-es": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
@@ -1300,9 +1300,9 @@
       }
     },
     "eslint-plugin-jest": {
-      "version": "24.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.0.tgz",
-      "integrity": "sha512-827YJ+E8B9PvXu/0eiVSNFfxxndbKv+qE/3GSMhdorCaeaOehtqHGX2YDW9B85TEOre9n/zscledkFW/KbnyGg==",
+      "version": "24.1.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jest/-/eslint-plugin-jest-24.1.3.tgz",
+      "integrity": "sha512-dNGGjzuEzCE3d5EPZQ/QGtmlMotqnYWD/QpCZ1UuZlrMAdhG5rldh0N0haCvhGnUkSeuORS5VNROwF9Hrgn3Lg==",
       "requires": {
         "@typescript-eslint/experimental-utils": "^4.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -39,13 +39,13 @@
     "plugin"
   ],
   "dependencies": {
+    "@babel/eslint-plugin": "7.12.1",
     "@typescript-eslint/eslint-plugin": "4.7.0",
     "@typescript-eslint/parser": "4.7.0",
     "babel-eslint": "10.1.0",
     "eslint-config-prettier": "6.15.0",
-    "eslint-plugin-babel": "5.3.1",
     "eslint-plugin-import": "2.22.1",
-    "eslint-plugin-jest": "24.1.0",
+    "eslint-plugin-jest": "24.1.3",
     "eslint-plugin-jsx-a11y": "6.4.1",
     "eslint-plugin-node": "11.1.0",
     "eslint-plugin-prettier": "3.1.4",

--- a/rules/index.js
+++ b/rules/index.js
@@ -19,7 +19,7 @@ const defaultParserOptions = {
   sourceType: 'module',
 }
 
-const defaultPlugins = ['babel', 'unicorn', 'promise', 'import']
+const defaultPlugins = ['@babel/eslint-plugin', 'unicorn', 'promise', 'import']
 
 const plugin = {
   configs: {

--- a/rules/recommended.js
+++ b/rules/recommended.js
@@ -1,10 +1,6 @@
 const baseRules = {
   'array-callback-return': 2,
   'arrow-body-style': [2, 'as-needed'],
-  'babel/no-unused-expressions': [
-    2,
-    { allowTernary: true, allowShortCircuit: true },
-  ],
   camelcase: [2, { properties: 'never' }],
   'comma-dangle': [
     2,


### PR DESCRIPTION
## Change Type

* [ ] Feature
* [x] Chore
* [ ] Bug Fix

## Further Information (screenshots, bug report links, etc)
i was having some issues after upgrading and found the repo had been archived