### PR TITLE
feat: turn off no-use-before-define when in TS because it will catch them [patch]

### DIFF
--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -111,11 +111,12 @@ const typescriptRules = {
   '@typescript-eslint/restrict-plus-operands': 2,
   '@typescript-eslint/semi': 0,
   '@typescript-eslint/type-annotation-spacing': 0,
+  '@typescript-eslint/explicit-module-boundary-types': 0,
   'no-unused-labels': 0,
+  'no-use-before-define': 0,
   'node/no-missing-import': 0,
   'node/no-missing-require': 0,
   camelcase: 0,
-  '@typescript-eslint/explicit-module-boundary-types': 0,
 }
 
 module.exports = { typescriptRules }


### PR DESCRIPTION
…those errors

## Change Type

* [x] Feature
* [ ] Chore
* [ ] Bug Fix

## Further Information (screenshots, bug report links, etc)
title. this rule started causing an error with react in the most recent updates