### PR TITLE
fix: allow pascal case for imports

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,4 +6,4 @@ Originally forked from `jane/eslint-plugin-jane`.
 
 
 # Contributing
-Be sure to `npm publish <type>` in each PR so the version can get published
+Be sure to `npm version <type>` in each PR so the version can get published

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@pdq/eslint-plugin-pdq",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@pdq/eslint-plugin-pdq",
-      "version": "2.5.5",
+      "version": "2.5.6",
       "license": "MIT",
       "dependencies": {
         "@babel/eslint-parser": "7.22.15",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@pdq/eslint-plugin-pdq",
   "description": "pdq's ESLint plugin and configurations",
-  "version": "2.5.5",
+  "version": "2.5.6",
   "author": "pdq",
   "license": "MIT",
   "main": "index.js",

--- a/rules/typescript.js
+++ b/rules/typescript.js
@@ -77,6 +77,10 @@ const typescriptRules = {
         match: false,
       },
     },
+    {
+      selector: 'import',
+      format: ['camelCase', 'PascalCase'],
+    },
   ],
   '@typescript-eslint/no-array-constructor': 2,
   '@typescript-eslint/no-empty-interface': 2,


### PR DESCRIPTION
After bumping to latest eslint-plugin-pdq in houston, got tons of errors like
```1:8  error  Import name `CancelIcon` must match one of the following formats: camelCase          @typescript-eslint/naming-convention```

See https://github.com/typescript-eslint/typescript-eslint/pull/7841